### PR TITLE
UI assets from localhost need not to be proxied anymore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7601,12 +7601,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.0.2.tgz",
-      "integrity": "sha512-iKg9hghcMQQOnb/n12cR/zs4WBEM3f9s4gOBHH7pSt+XhZQrwIHAvuN+P541hy1kiBQggZiX874BOSgHgt90Vw==",
-      "dev": true
-    },
     "prop-types": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
@@ -8483,12 +8477,10 @@
       }
     },
     "scrivito": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/scrivito/-/scrivito-0.4.0.tgz",
-      "integrity": "sha512-SxjQGoL27d74VcxkhmSTGzSwXP8OeKb4FVF0PkqTiZ7k/R5RNJdBHXu/o9KN9bw9FBvi17AUuiOLFNDZDgplbw==",
+      "version": "file:../rails_connector/js/build/npm_scrivito",
       "dev": true,
       "requires": {
-        "promise-polyfill": "7.0.2",
+        "promise-polyfill": "7.0.0",
         "prop-types": "15.6.0",
         "react": "16.2.0",
         "react-dom": "16.2.0",
@@ -8496,6 +8488,174 @@
         "tcomb-validation": "3.4.1",
         "underscore": "1.8.3",
         "urijs": "1.19.0"
+      },
+      "dependencies": {
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "promise-polyfill": {
+          "version": "7.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "react": {
+          "version": "16.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "speakingurl": {
+          "version": "11.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tcomb": {
+          "version": "3.2.24",
+          "bundled": true,
+          "dev": true
+        },
+        "tcomb-validation": {
+          "version": "3.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tcomb": "3.2.24"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true,
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true,
+          "dev": true
+        },
+        "urijs": {
+          "version": "1.19.0",
+          "bundled": true,
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        }
       }
     },
     "scss-tokenizer": {
@@ -8949,12 +9109,6 @@
         "wbuf": "1.7.2"
       }
     },
-    "speakingurl": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-11.0.0.tgz",
-      "integrity": "sha1-IOXO/AmzL8/jnuCy6XiT+zkoGbM=",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9294,21 +9448,6 @@
         "block-stream": "0.0.9",
         "fstream": "1.0.11",
         "inherits": "2.0.3"
-      }
-    },
-    "tcomb": {
-      "version": "3.2.24",
-      "resolved": "https://registry.npmjs.org/tcomb/-/tcomb-3.2.24.tgz",
-      "integrity": "sha512-N9IrL2iIyS/f4+WHYZaMh04ZqDL8yEit9cVdnn+fOuL6jbKo1fusNswHOjSo/kbYwLUKRS1OlQmAkyeNxyEUhA==",
-      "dev": true
-    },
-    "tcomb-validation": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tcomb-validation/-/tcomb-validation-3.4.1.tgz",
-      "integrity": "sha512-urVVMQOma4RXwiVCa2nM2eqrAomHROHvWPuj6UkDGz/eb5kcy0x6P0dVt6kzpUZtYMNoAqJLWmz1BPtxrtjtrA==",
-      "dev": true,
-      "requires": {
-        "tcomb": "3.2.24"
       }
     },
     "through": {
@@ -9659,12 +9798,6 @@
         "invariant": "2.2.2"
       }
     },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
@@ -9803,12 +9936,6 @@
           "dev": true
         }
       }
-    },
-    "urijs": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz",
-      "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw==",
-      "dev": true
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-scroll": "^1.7.6",
     "react-slick": "^0.17.1",
     "sass-loader": "^6.0.6",
-    "scrivito": "^0.4.0",
+    "scrivito": "file:../rails_connector/js/build/npm_scrivito",
     "slick-carousel": "^1.6.0",
     "striptags": "^2.2.1",
     "uglifyjs-webpack-plugin": "^1.1.8",

--- a/readme.mdown
+++ b/readme.mdown
@@ -80,6 +80,17 @@ Calling `npm run build` will compile all JS, HTML and CSS and place it in the `b
 
 Calling `npm start` will start a webserver, which listens to [localhost:8080](http://localhost:8080/) and opens this URL in your browser. It should also automatically reload the page after changes to the code (in `src/`) have been made.
 
+This branch is configured to use a dev version of the SDK located
+at ../rails_connector. So before you `npm start` the app, have these
+steps executed:
+```
+# You already have forked and cloned rails_connector, don't you?
+cd ../rails_connector/js
+yarn package:npm:watch # creates a scrivito/NPM into ../rails_connector/js/build/npm_scrivito
+                       # For a one-time compile, use yarn package:npm:dev
+yarn start             # serves the UI at localhost:8090/scrivito
+```
+
 ## Your first change
 
 To see development in action, let's change the `ButtonWidget` so that it prefixes all buttons with your favorite emoji.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,6 +137,9 @@ module.exports = (env = {}) => {
     },
     devServer: {
       port: 8080,
+      proxy: {
+        "/scrivito": { target: "http://localhost:8090" },
+      },
       historyApiFallback: {
         rewrites: [
           { from: /^\/scrivito/, to: '/scrivito/index.html' },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,9 +137,6 @@ module.exports = (env = {}) => {
     },
     devServer: {
       port: 8080,
-      proxy: {
-        "/scrivito": { target: "http://localhost:8090" },
-      },
       historyApiFallback: {
         rewrites: [
           { from: /^\/scrivito/, to: '/scrivito/index.html' },


### PR DESCRIPTION
Note: requires infopark/rails_connector#3782 (be merged)

Instead, they are delivered by UI's dev server directly. This is simply
similar to the "assets from CDN" case, where the application does not
proxy assets either.

To get the fully dynamic scrivito, you can even run
  yarn package:npm:watch
to have scrivito/npm updated live.

For everything, the commands are

```
npm install            # syncs your scrivito with the remote one

# cd rails_connector/js
yarn                   # bootstrap 1 - every now and then
yarn package:dev_deps  # bootstrap 2 - every now and then

yarn start             # UI dev server @ port 8090
yarn package:npm:watch # Live-update of your scrivito/NPM
  # or
yarn package:npm       # If "files on disk" is sufficient

# cd scrivito_example_app_js
npm start
```