### PR TITLE
small improvements

### DIFF
--- a/src/Widgets/FormContainerWidget/FormContainerWidget.scss
+++ b/src/Widgets/FormContainerWidget/FormContainerWidget.scss
@@ -8,4 +8,12 @@
     font-weight: bold;
     color: red;
   }
+  .text-mandatory:hover { cursor: help; }
 }
+
+/* popover styles used in forms
+=================================================================== */
+
+.fa.fa-question-circle:hover { cursor: help; }
+.popover p { margin: 0; }
+

--- a/src/Widgets/FormTextInputWidget/FormTextInputWidgetComponent.js
+++ b/src/Widgets/FormTextInputWidget/FormTextInputWidgetComponent.js
@@ -34,7 +34,7 @@ Scrivito.provideComponent("FormTextInputWidget", ({ widget }) => {
 
       {widget.get("description") ? (
         <>
-          <i className="fa fa-question-circle fa-1x" id={questionId}></i>
+          <i className="fa fa-question-circle fa-1x ml-2" id={questionId}></i>
           <Popover
             placement="bottom"
             isOpen={popoverOpen}

--- a/src/assets/stylesheets/bootstrap/bootstrap.scss
+++ b/src/assets/stylesheets/bootstrap/bootstrap.scss
@@ -36,7 +36,7 @@
 /*@import "close";*/
 /*@import "modal";*/
 /*@import "tooltip";*/
-/*@import "popover";*/
+@import "popover";
 @import "carousel";
 @import "utilities";
 @import "print";


### PR DESCRIPTION
@apepper  Updates for use. Not too much time spent on design (because every designer wants to change it anyway). I use standard BS4 popover stylings. So if you are already styled your popover.. you will have the same style here.

![popover](https://user-images.githubusercontent.com/710311/143030518-c969539d-e2c2-461f-9bd8-596c151c4f0c.gif)

I would like to have a different mode for popover Triggers. There is a "focus mode". At the moment you have to hit the question icon again to close popover. 
https://deploy-preview-2356--reactstrap.netlify.app/components/popovers/

