### PR TITLE
HiddenField fixes

### DIFF
--- a/src/Widgets/FormContainerWidget/FormContainerWidgetComponent.js
+++ b/src/Widgets/FormContainerWidget/FormContainerWidgetComponent.js
@@ -102,7 +102,5 @@ const HiddenField = Scrivito.connect(({ widget }) => {
     return null;
   }
 
-  return (
-    <input type="hidden" name={name} value={widget.get("customHiddenValue")} />
-  );
+  return <input type="hidden" name={name} value={widget.get("hiddenValue")} />;
 });

--- a/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetEditingConfig.js
+++ b/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetEditingConfig.js
@@ -4,7 +4,6 @@ import { customFieldNameValidation } from "../FormContainerWidget/utils/validati
 
 Scrivito.provideEditingConfig("FormHiddenFieldWidget", {
   title: "Hidden Field",
-  hideInSelectionDialogs: true,
   attributes: {
     customFieldName: { title: "Field name" },
     hiddenValue: {


### PR DESCRIPTION
`hideInSelectionDialogs: true` can't be added, because otherwise the hidden field widget can't be added to the form container widget. I don't yet know of a better why how to handle this. With this change, the "Hidden Field" also shows up in the widget library.