### PR TITLE
[FormContainerWidget] Make use of Scrivito's 1.29.0 initilaizeCopy

### DIFF
--- a/src/Widgets/FormContainerWidget/FormContainerWidgetEditingConfig.js
+++ b/src/Widgets/FormContainerWidget/FormContainerWidgetEditingConfig.js
@@ -104,6 +104,9 @@ Scrivito.provideEditingConfig("FormContainerWidget", {
       new FormButtonWidget(),
     ],
   },
+  initializeCopy: (widget) => {
+    widget.update({ formId: pseudoRandom32CharHex() });
+  },
   validations: [
     (widget) => {
       if (getFormContainer(widget)) {


### PR DESCRIPTION
If a form is added as a template and that template gets inserted, the formId should be regenerated to avoid form collisions in Neoletter.

See https://www.scrivito.com/scrivito-js-sdk-1-29-0-released-f7dab02769bdb921#keeping-copied-pages-and-widgets-consistent for more details