### PR TITLE
Converted all form widgets to named exports

### DIFF
--- a/src/Widgets/FormButtonWidget/FormButtonWidgetClass.js
+++ b/src/Widgets/FormButtonWidget/FormButtonWidgetClass.js
@@ -1,11 +1,12 @@
 import * as Scrivito from "scrivito";
 
-const FormButtonWidget = Scrivito.provideWidgetClass("FormButtonWidget", {
-  attributes: {
-    buttonText: "string",
-    alignment: ["enum", { values: ["left", "center", "right", "block"] }],
-  },
-  extractTextAttributes: ["buttonText"],
-});
-
-export default FormButtonWidget;
+export const FormButtonWidget = Scrivito.provideWidgetClass(
+  "FormButtonWidget",
+  {
+    attributes: {
+      buttonText: "string",
+      alignment: ["enum", { values: ["left", "center", "right", "block"] }],
+    },
+    extractTextAttributes: ["buttonText"],
+  }
+);

--- a/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetClass.js
+++ b/src/Widgets/FormCheckboxWidget/FormCheckboxWidgetClass.js
@@ -1,13 +1,14 @@
 import * as Scrivito from "scrivito";
 
-const FormCheckboxWidget = Scrivito.provideWidgetClass("FormCheckboxWidget", {
-  attributes: {
-    type: ["enum", { values: ["custom", "accept_terms"] }],
-    customFieldName: "string",
-    label: "string",
-    required: "boolean",
-    helpText: "html",
-  },
-});
-
-export default FormCheckboxWidget;
+export const FormCheckboxWidget = Scrivito.provideWidgetClass(
+  "FormCheckboxWidget",
+  {
+    attributes: {
+      type: ["enum", { values: ["custom", "accept_terms"] }],
+      customFieldName: "string",
+      label: "string",
+      required: "boolean",
+      helpText: "html",
+    },
+  }
+);

--- a/src/Widgets/FormContainerWidget/FormContainerWidgetClass.js
+++ b/src/Widgets/FormContainerWidget/FormContainerWidgetClass.js
@@ -1,15 +1,16 @@
 import * as Scrivito from "scrivito";
 
-const FormContainerWidget = Scrivito.provideWidgetClass("FormContainerWidget", {
-  attributes: {
-    content: "widgetlist",
-    formId: "string",
-    failedMessage: "string",
-    submittedMessage: "string",
-    submittingMessage: "string",
-    hiddenFields: ["widgetlist", { only: "FormHiddenFieldWidget" }],
-  },
-  extractTextAttributes: ["content"],
-});
-
-export default FormContainerWidget;
+export const FormContainerWidget = Scrivito.provideWidgetClass(
+  "FormContainerWidget",
+  {
+    attributes: {
+      content: "widgetlist",
+      formId: "string",
+      failedMessage: "string",
+      submittedMessage: "string",
+      submittingMessage: "string",
+      hiddenFields: ["widgetlist", { only: "FormHiddenFieldWidget" }],
+    },
+    extractTextAttributes: ["content"],
+  }
+);

--- a/src/Widgets/FormContainerWidget/FormContainerWidgetEditingConfig.js
+++ b/src/Widgets/FormContainerWidget/FormContainerWidgetEditingConfig.js
@@ -1,11 +1,11 @@
 import * as Scrivito from "scrivito";
 import loadable from "@loadable/component";
 import formContainerWidgetIcon from "../../assets/images/form_container_widget.svg";
-import ColumnContainerWidget from "../ColumnContainerWidget/ColumnContainerWidgetClass";
-import ColumnWidget from "../ColumnWidget/ColumnWidgetClass";
-import FormButtonWidget from "../FormButtonWidget/FormButtonWidgetClass";
-import FormInputFieldWidget from "../FormInputFieldWidget/FormInputFieldWidgetClass";
-import TextWidget from "../TextWidget/TextWidgetClass";
+import { ColumnContainerWidget } from "../ColumnContainerWidget/ColumnContainerWidgetClass";
+import { ColumnWidget } from "../ColumnWidget/ColumnWidgetClass";
+import { FormButtonWidget } from "../FormButtonWidget/FormButtonWidgetClass";
+import { FormInputFieldWidget } from "../FormInputFieldWidget/FormInputFieldWidgetClass";
+import { TextWidget } from "../TextWidget/TextWidgetClass";
 import { pseudoRandom32CharHex } from "./utils/pseudoRandom32CharHex";
 import { getFormContainer } from "./utils/getFormContainer";
 

--- a/src/Widgets/FormContainerWidget/FormIdComponent.js
+++ b/src/Widgets/FormContainerWidget/FormIdComponent.js
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as Scrivito from "scrivito";
-import ContentProperty from "../../Components/ScrivitoExtensions/ContentProperty";
+import { ContentProperty } from "../../Components/ScrivitoExtensions/ContentProperty";
 
-const FormIdComponent = Scrivito.connect(({ widget }) => {
+export const FormIdComponent = Scrivito.connect(({ widget }) => {
   const formSubmissionsHref = widget.get("formId")
     ? `https://neoletter.com/i/${
         process.env.SCRIVITO_TENANT
@@ -33,5 +33,3 @@ const FormIdComponent = Scrivito.connect(({ widget }) => {
     </div>
   );
 });
-
-export default FormIdComponent;

--- a/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetClass.js
+++ b/src/Widgets/FormHiddenFieldWidget/FormHiddenFieldWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const FormHiddenFieldWidget = Scrivito.provideWidgetClass(
+export const FormHiddenFieldWidget = Scrivito.provideWidgetClass(
   "FormHiddenFieldWidget",
   {
     onlyInside: "FormContainerWidget",
@@ -10,5 +10,3 @@ const FormHiddenFieldWidget = Scrivito.provideWidgetClass(
     },
   }
 );
-
-export default FormHiddenFieldWidget;

--- a/src/Widgets/FormInputFieldWidget/FormInputFieldWidgetClass.js
+++ b/src/Widgets/FormInputFieldWidget/FormInputFieldWidgetClass.js
@@ -1,6 +1,6 @@
 import * as Scrivito from "scrivito";
 
-const FormInputFieldWidget = Scrivito.provideWidgetClass(
+export const FormInputFieldWidget = Scrivito.provideWidgetClass(
   "FormInputFieldWidget",
   {
     attributes: {
@@ -28,5 +28,3 @@ const FormInputFieldWidget = Scrivito.provideWidgetClass(
     },
   }
 );
-
-export default FormInputFieldWidget;


### PR DESCRIPTION
Diff best viewed without whitespace changes.

In defaultToNamedExport:

> npx jscodeshift --extensions=jsx,js --transform defaultToNamedExport.ts ../scrivito_example_app_js/src/**/*.js